### PR TITLE
Add support for custom scripts

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/jenkins/postunpack.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/jenkins/postunpack.sh
@@ -17,7 +17,7 @@ set -o pipefail
 
 # Ensure required directories exist
 chmod g+rwX "$JENKINS_BASE_DIR"
-for dir in "$JENKINS_HOME" "${JENKINS_BASE_DIR}/plugins" "$JENKINS_TMP_DIR" "$JENKINS_LOGS_DIR"; do
+for dir in "$JENKINS_VOLUME_DIR" "$JENKINS_HOME" "${JENKINS_BASE_DIR}/plugins" "$JENKINS_TMP_DIR" "$JENKINS_LOGS_DIR"; do
     ensure_dir_exists "$dir"
     configure_permissions_ownership "$dir" -d "775" -f "664"
 done

--- a/2/debian-10/rootfs/opt/bitnami/scripts/jenkins/setup.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/jenkins/setup.sh
@@ -25,3 +25,5 @@ fi
 
 # Ensure Jenkins is initialized
 jenkins_initialize
+# Allow running custom initialization scripts
+jenkins_custom_init_scripts

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libjenkins.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libjenkins.sh
@@ -349,7 +349,7 @@ jenkins_add_custom_file() {
 #   None
 #########################
 jenkins_custom_init_scripts() {
-    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|groovy\)") ]] && [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|groovy\)") ]] && [[ ! -f "${JENKINS_VOLUME_DIR}/.user_scripts_initialized" ]] ; then
         info "Loading user's custom files from /docker-entrypoint-initdb.d";
         for f in /docker-entrypoint-initdb.d/*; do
             debug "Executing $f"
@@ -378,6 +378,6 @@ jenkins_custom_init_scripts() {
                     ;;
             esac
         done
-        touch "$DB_DATA_DIR"/.user_scripts_initialized
+        touch "${JENKINS_VOLUME_DIR}/.user_scripts_initialized"
     fi
 }

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libjenkins.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libjenkins.sh
@@ -338,3 +338,46 @@ jenkins_add_custom_file() {
         echo "$action $relpath : $reason" >> "${JENKINS_LOGS_DIR}/copy_reference_file.log"
     fi
 }
+
+########################
+# Run custom initialization scripts
+# Globals:
+#   DB_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+jenkins_custom_init_scripts() {
+    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|groovy\)") ]] && [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] ; then
+        info "Loading user's custom files from /docker-entrypoint-initdb.d";
+        for f in /docker-entrypoint-initdb.d/*; do
+            debug "Executing $f"
+            case "$f" in
+                *.sh)
+                    if [[ -x "$f" ]]; then
+                        if ! "$f"; then
+                            error "Failed executing $f"
+                            return 1
+                        fi
+                    else
+                        warn "Sourcing $f as it is not executable by the current user, any error may cause initialization to fail"
+                        . "$f"
+                    fi
+                    ;;
+                *.groovy)
+                    cp "$f" "${JENKINS_HOME}/init.groovy.d"
+                    jenkins_start_bg
+                    jenkins_stop
+                    # Rotate the logs in Jenkins
+                    mv "$JENKINS_LOG_FILE" "${JENKINS_LOGS_DIR}/jenkins.initscripts.log"
+                    rm "${JENKINS_HOME}/init.groovy.d/$(basename $f)"
+                    ;;
+                *)
+                    warn "Skipping $f, supported formats are: .sh .sql .sql.gz"
+                    ;;
+            esac
+        done
+        touch "$DB_DATA_DIR"/.user_scripts_initialized
+    fi
+}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds the possibility of mounting custom scripts (`.sh` or `.groovy` extensions) in the `/docker-entrypoint-initdb.d/` entrypoint so users can customize the Jenkins initialization.

**Benefits**

Customization

**Possible drawbacks**

None

**Applicable issues**

- fixes #77

**Additional information**

N/A
